### PR TITLE
Updated run.sh to support Macs with Apple silicon processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ sum(k^2, k, 1, 10)
 
 [insect](https://github.com/sharkdp/insect)
 
-```sh
+```bash
 brew install insect
-# or
-npm install -g insect
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This workflow adds a powerful calculator right in your Alfred bar.
 
 1. Install [Homebrew](https://brew.sh/).
 
-2. Install [insect](https://github.com/sharkdp/insect).
+2. Install insect:
 
 ```bash
 brew install insect
 ```
 
-3. Then download the [CLC workflow file](https://github.com/aviaryan/alfred-clc/raw/master/clc.alfredworkflow), and double-click it to have it open in Alfred.
+3. Download the [CLC workflow file](https://github.com/aviaryan/alfred-clc/raw/master/clc.alfredworkflow), and double-click it to have it open in Alfred.
 
 
 ## Using

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ This workflow adds a powerful calculator right in your Alfred bar.
 
 ## Installing
 
-Install [insect](https://github.com/sharkdp/insect)
+1. Install [Homebrew](https://brew.sh/).
 
-```sh
+2. Install [insect](https://github.com/sharkdp/insect).
+
+```bash
 brew install insect
 ```
 
-Then download [CLC workflow file](https://github.com/aviaryan/alfred-clc/raw/master/clc.alfredworkflow) and double click to open it with Alfred.
+3. Then download the [CLC workflow file](https://github.com/aviaryan/alfred-clc/raw/master/clc.alfredworkflow), and double-click it to have it open in Alfred.
 
 
 ## Using

--- a/src/run.sh
+++ b/src/run.sh
@@ -7,7 +7,7 @@
 # `autocomplete` needed to keep ScriptFilter result
 #
 
-query=$1
+query="$1"
 PATH=$PATH:/usr/local/bin
 answer=$(echo "$1" | insect)
 # answer=$(which /usr/local/bin/insect)

--- a/src/run.sh
+++ b/src/run.sh
@@ -8,7 +8,19 @@
 #
 
 query="$1"
-PATH=$PATH:/usr/local/bin
+
+if [ -f "/opt/homebrew/bin/brew" ]; then
+	brew_path="/opt/homebrew/bin"
+	echo "/opt/homebrew/bin detected as Homebrew binary directory" >&2
+elif [ -f "/usr/local/bin/brew" ]; then
+	brew_path="/usr/local/bin"
+	echo "/usr/local/bin detected as Homebrew binary directory" >&2
+else
+	printf "Unable to find path to Homebrew. Please ensure that it is installed from https://brew.sh/.\n" >&2
+	exit 1
+fi
+
+PATH=$brew_path:$PATH
 answer=$(echo "$query" | insect)
 
 cat << EOB

--- a/src/run.sh
+++ b/src/run.sh
@@ -25,7 +25,6 @@ answer=$(echo "$query" | insect)
 
 cat << EOB
 {"items": [
-
 	{
 		"uid": "$query",
 		"title": "$answer",
@@ -36,6 +35,5 @@ cat << EOB
 			"path": "icon.png"
 		}
 	}
-
 ]}
 EOB

--- a/src/run.sh
+++ b/src/run.sh
@@ -15,9 +15,12 @@ if [ -f "/opt/homebrew/bin/insect" ]; then
 elif [ -f "/usr/local/bin/insect" ]; then
 	brew_prefix="/usr/local"
 	echo "/usr/local/bin detected as Homebrew binary directory" >&2
-else
-	printf "Unable to find path to Homebrew. Please ensure that it is installed from https://brew.sh/.\n" >&2
+elif [ ! -f "/opt/homebrew/bin/brew" ] && [ ! -f "/usr/local/bin/brew" ]; then
+	printf "Unable to find Homebrew in default installation directories. Please ensure it is installed from here: https://brew.sh/.\n" >&2
 	exit 1
+else
+    printf "Unable to find insect in Homebrew installation directory. Please install it by running the following: brew install insect.\n" >&2
+    exit 1
 fi
 
 PATH="$brew_prefix/bin:$PATH"

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,14 +1,11 @@
 #!/bin/zsh
 
 # NOTES
-# 
+#
 # bash was not working
 # `arg` goes as output from here
 # `autocomplete` needed to keep ScriptFilter result
-# 
-
-# force set PATH (https://github.com/aviaryan/alfred-clc/issues/1)
-# PATH=$($(echo $SHELL) -ic 'echo $PATH'):/usr/local/bin:$PATH
+#
 
 query=$1
 PATH=$PATH:/usr/local/bin

--- a/src/run.sh
+++ b/src/run.sh
@@ -20,7 +20,7 @@ else
 	exit 1
 fi
 
-PATH=$brew_path:$PATH
+PATH="$brew_path:$PATH"
 answer=$(echo "$query" | insect)
 
 cat << EOB

--- a/src/run.sh
+++ b/src/run.sh
@@ -10,7 +10,6 @@
 query="$1"
 PATH=$PATH:/usr/local/bin
 answer=$(echo "$1" | insect)
-# answer=$(which /usr/local/bin/insect)
 
 cat << EOB
 {"items": [

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,10 +9,10 @@
 
 query="$1"
 
-if [ -f "/opt/homebrew/bin/brew" ]; then
+if [ -f "/opt/homebrew/bin/insect" ]; then
 	brew_prefix="/opt/homebrew"
 	echo "/opt/homebrew/bin detected as Homebrew binary directory" >&2
-elif [ -f "/usr/local/bin/brew" ]; then
+elif [ -f "/usr/local/bin/insect" ]; then
 	brew_prefix="/usr/local"
 	echo "/usr/local/bin detected as Homebrew binary directory" >&2
 else

--- a/src/run.sh
+++ b/src/run.sh
@@ -10,17 +10,17 @@
 query="$1"
 
 if [ -f "/opt/homebrew/bin/brew" ]; then
-	brew_path="/opt/homebrew/bin"
+	brew_prefix="/opt/homebrew"
 	echo "/opt/homebrew/bin detected as Homebrew binary directory" >&2
 elif [ -f "/usr/local/bin/brew" ]; then
-	brew_path="/usr/local/bin"
+	brew_prefix="/usr/local"
 	echo "/usr/local/bin detected as Homebrew binary directory" >&2
 else
 	printf "Unable to find path to Homebrew. Please ensure that it is installed from https://brew.sh/.\n" >&2
 	exit 1
 fi
 
-PATH="$brew_path:$PATH"
+PATH="$brew_prefix/bin:$PATH"
 answer=$(echo "$query" | insect)
 
 cat << EOB

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,7 +9,7 @@
 
 query="$1"
 PATH=$PATH:/usr/local/bin
-answer=$(echo "$1" | insect)
+answer=$(echo "$query" | insect)
 
 cat << EOB
 {"items": [


### PR DESCRIPTION
- Updated README to include Homebrew installation in the instructions
- Removed the insect repo from the installation instructions to prevent confusion (already included later in the README anyway)
- Updated `run.sh` to choose between potential Homebrew directories depending on where `insect` is installed, providing error messages in the Alfred debugger if not found
- Updated minor formatting and code issues in run.sh

You may wish to update the version number if this PR is merged.

Also, I wasn't sure how to update the `clc.alfredworkflow` file to add the `run.sh` changes, so please add those changes to this PR if you plan to merge it.